### PR TITLE
chore Upgrade django #161278896

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ ENV/
 
 # SQLite3
 db.sqlite3
+.vscode/
+migrations/

--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -1,10 +1,9 @@
 # import jwt
-#
+
 # from django.conf import settings
-#
+
 # from rest_framework import authentication, exceptions
-#
+
 # from .models import User
 
 """Configure JWT Here"""
-

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -4,6 +4,7 @@ from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView
 )
 
+app_name = "authentication"
 urlpatterns = [
     url(r'^user/?$', UserRetrieveUpdateAPIView.as_view()),
     url(r'^users/?$', RegistrationAPIView.as_view()),

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
+    # 'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -19,6 +19,6 @@ from django.contrib import admin
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
 
-    url(r'^api/', include('authors.apps.authentication.urls', namespace='authentication')),
+    url(r'^api/', include('authors.apps.authentication.urls')),
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10
+Django==2.1
 django-cors-middleware==1.2.0
 django-extensions==1.7.1
 djangorestframework==3.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,13 @@
+astroid==2.0.4
 Django==2.1
 django-cors-middleware==1.2.0
-django-extensions==1.7.1
-djangorestframework==3.4.4
+django-extensions==2.1.3
+djangorestframework==3.9.0
+isort==4.3.4
+lazy-object-proxy==1.3.1
+mccabe==0.6.1
 PyJWT==1.4.2
+pylint==2.1.1
+pytz==2018.5
 six==1.10.0
+wrapt==1.10.11


### PR DESCRIPTION

## What does this Pull Request Do?
Upgrade django 1.11 to django 2.1

## Description of Task to be completed
Upgrading to django 2.1 because django 1.11 is no longer supported thus vulnerable to security, and
Django 2.x is the latest release of Django with full support of Python 3.x series.
## How should this be manually tested?
- On your local machine, clone the repository `https://github.com/andela/ah-sealteam` 
- Navigate to the folder `$ cd ah-sealteam`
- Run command `$ django --version` to see the version of django