### PR TITLE
#161278906 Enable token in registration and login

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,4 +7,5 @@ omit =
   *venv/*,
   *urls.py,
   *wsgi/*,
-  manage.py
+  manage.py,
+  *env/*

--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -1,11 +1,29 @@
-# import jwt
+import jwt
 
-# from django.conf import settings
+from django.conf import settings
 
-# from rest_framework import authentication, exceptions
+from rest_framework import authentication, exceptions
 
-# from .models import User
+from .models import User
 
 """Configure JWT Here"""
-class JWTAuthentication:
-    pass
+
+
+class JWTAuthentication(authentication.BaseAuthentication):
+    """This class will override default Base authentication and do authentication with Token"""
+
+    def authenticate(self, request):
+        """This methods overrides the base method and does the authentication"""
+        token = authentication.get_authorization_header(request).decode('utf - 8')
+        if not token:
+            return None
+        try:
+            token = token.split(" ")[1]
+            payload = jwt.decode(token, settings.SECRET_KEY)
+        except Exception as e:
+            raise exceptions.AuthenticationFailed("Invalid token what")
+        try:
+            user = User.objects.get(pk=payload['id'])
+        except User.DoesNotExist:
+            raise exceptions.AuthenticationFailed("User does not exist")
+        return user, token

--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -117,4 +117,13 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         return self.username
 
+    def token(self):
+        """This method creates a token for a user who registers or logs in successfully"""
+        data = {
+            "id": self.id,
+            "username": self.username,
+            "exp": datetime.now() + timedelta(days=1)
+        }
+        return jwt.encode(data, settings.SECRET_KEY).decode('utf-8')
+
 

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -23,7 +23,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
         model = User
         # List all of the fields that could possibly be included in a request
         # or response, including fields specified explicitly above.
-        fields = ['email', 'username', 'password']
+        fields = ['email', 'username', 'password', 'token']
 
     def create(self, validated_data):
         # Use the `create_user` method we wrote earlier to create a new user.
@@ -34,7 +34,7 @@ class LoginSerializer(serializers.Serializer):
     email = serializers.CharField(max_length=255)
     username = serializers.CharField(max_length=255, read_only=True)
     password = serializers.CharField(max_length=128, write_only=True)
-
+    token = serializers.CharField(read_only=True, max_length=255)
 
     def validate(self, data):
         # The `validate` method is where we make sure that the current
@@ -87,6 +87,7 @@ class LoginSerializer(serializers.Serializer):
         return {
             'email': user.email,
             'username': user.username,
+            'token':user.token,
 
         }
 

--- a/authors/apps/authentication/tests/test_user_login.py
+++ b/authors/apps/authentication/tests/test_user_login.py
@@ -1,5 +1,6 @@
 from authors.base_test import BaseTestCase
 
+
 class TestUserLogin(BaseTestCase):
     """
     This class logs in a user who has an account in the application
@@ -7,25 +8,61 @@ class TestUserLogin(BaseTestCase):
     """
 
     def test_user_login(self):
-        with self.client:
-            pass
+        data = {
+            "user": {
+                "email": self.email,
+                "password": self.password
+            }
+        }
+        response = self.client.post(self.login_url, data, format='json')
+        self.assertEqual(response.status_code, 200)
+        assert response.data['email'] == self.email
+        assert response.data['username'] == self.username
+        assert response.data.get("token")
 
     def test_user_login_with_invalid_password(self):
-        with self.client:
-            pass
+        data = {
+            "user": {
+                "email": self.email,
+                "password": "ndssjdknkjf"
+            }
+        }
+        response = self.client.post(self.login_url, data, format='json')
+        self.assertEqual(response.status_code, 400)
+        assert response.data['errors']["error"][0] == "A user with this email and password was not found."
 
     def test_user_login_with_no_email(self):
-        with self.client:
-            pass
+        data = {
+            "user": {
+                "email": "",
+                "password": "ndssjdknkjf"
+            }
+        }
+        response = self.client.post(self.login_url, data, format='json')
+        self.assertEqual(response.status_code, 400)
+        assert response.data['errors']["email"][0] == "This field may not be blank."
 
     def test_user_login_with_no_password(self):
-        with self.client:
-            pass
+        data = {
+            "user": {
+                "email": self.email,
+                "password": ""
+            }
+        }
+        response = self.client.post(self.login_url, data, format='json')
+        self.assertEqual(response.status_code, 400)
+        assert response.data['errors']["password"][0] == "This field may not be blank."
 
     def test_user_login_without_an_account(self):
-        with self.client:
-            pass
+        data = {
+            "user": {
+                "email": "noaccount@fma.com",
+                "password": "ndssjdknkjf"
+            }
+        }
+        response = self.client.post(self.login_url, data, format='json')
+        self.assertEqual(response.status_code, 400)
+        assert response.data['errors']["error"][0] == "A user with this email and password was not found."
 
     def test_user_login_with_deactivated_account(self):
-        with self.client:
-            pass
+        pass

--- a/authors/apps/authentication/tests/test_user_register.py
+++ b/authors/apps/authentication/tests/test_user_register.py
@@ -1,6 +1,7 @@
-from django.urls import reverse
 from rest_framework import status
+
 from authors.base_test import BaseTestCase
+
 
 class TestUserRegistration(BaseTestCase):
     """
@@ -11,23 +12,56 @@ class TestUserRegistration(BaseTestCase):
         """
         Ensures user can create a new account
         """
-        with self.client:
-            url = reverse('create_user')
-            response = self.client.post(url, self.new_user, format='json')
-            self.assertEqual(response.status, status.HTTP_201_CREATED)
+        response = self.client.post(self.register_url, self.new_user, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.data['email'] == "asheuh@gmail.com"
+        assert response.data['username'] == "asheuh"
+        assert response.data.get("token")
 
     def test_user_register_with_invalid_email(self):
-        with self.client:
-            pass
+        data={
+            "user":{
+                "email":self.wrongmail,
+                "username":self.username,
+                "password": "ajkjndsjnsd"
+            }
+        }
+        response = self.client.post(self.register_url,data , format='json')
+        self.assertEqual(response.status_code, 400)
+        assert response.data['errors']["email"][0] == "Enter a valid email address."
 
     def test_user_register_with_no_password(self):
-        with self.client:
-            pass
+        data = {
+            "user": {
+                "email": self.email,
+                "username": self.username,
+                "password":""
+            }
+        }
+        response = self.client.post(self.register_url, data, format='json')
+        self.assertEqual(response.status_code, 400)
+        assert response.data['errors']["password"][0] == "This field may not be blank."
 
     def test_user_register_with_no_email(self):
-        with self.client:
-            pass
+        data = {
+            "user": {
+                "email": "",
+                "username": self.username,
+                "password": "sgdssdhbd"
+            }
+        }
+        response = self.client.post(self.register_url, data, format='json')
+        self.assertEqual(response.status_code, 400)
+        assert response.data['errors']["email"][0] == "This field may not be blank."
 
     def test_register_if_user_already_exists(self):
-        with self.client:
-            pass
+        response = self.client.post(self.register_url, self.new_user, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.data['email'] == "asheuh@gmail.com"
+        assert response.data['username'] == "asheuh"
+        assert response.data.get("token")
+        response = self.client.post(self.register_url, self.new_user, format='json')
+        # import pdb;pdb.set_trace()
+        assert response.status_code==400
+        assert response.data["errors"]["email"][0] == "user with this email already exists."
+        assert response.data["errors"]["username"][0] == "user with this username already exists."

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -8,5 +8,5 @@ app_name = "authentication"
 urlpatterns = [
     url(r'^user/?$', UserRetrieveUpdateAPIView.as_view(), name='update_user'),
     url(r'^users/?$', RegistrationAPIView.as_view(), name='register'),
-    url(r'^users/login/?$', LoginAPIView.as_view(), nam='login'),
+    url(r'^users/login/?$', LoginAPIView.as_view(), name='login'),
 ]

--- a/authors/base_test.py
+++ b/authors/base_test.py
@@ -1,6 +1,8 @@
+from django.urls import reverse
 from rest_framework.test import APIClient
 from django.test import TestCase
 from .apps.authentication.models import User
+
 
 class BaseTestCase(TestCase):
     """
@@ -11,10 +13,32 @@ class BaseTestCase(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.new_user = {
-            'username': 'asheuh',
-            'email': 'asheuh@gmail.com',
-            'password': 'Mermaid@914'
+            "user": {'username': 'asheuh',
+                     'email': 'asheuh@gmail.com',
+                     'password': 'Mermaid@914'
+                     }
         }
-        User.objects.create_superuser(self.new_user.get('username'),
-                                 self.new_user.get('email'), self.new_user.get('password'))
+        self.register_url = reverse('authentication:register')
+        self.user_url = reverse('authentication:update_user')
+        self.username = "mike"
+        self.wrongmail = "dennis mail.com"
+        self.email = "testemail@gmail.com"
+        self.password = "testpassword"
+        self.login_url = reverse("authentication:login")
+        # this user will be used to test login
+        User.objects.create_user(username=self.username,
+                                 email=self.email, password=self.password)
+        data_for_get_test = {
+            "user": {
+                "email": self.email,
+                "password": self.password
+            }
+        }
+        response = self.client.post(self.login_url, data_for_get_test, format='json')
+        self.token = response.data["token"]
+        self.assertEqual(response.status_code, 200)
+        assert response.data['email'] == self.email
+        assert response.data['username'] == self.username
+        assert response.data.get("token")
+
 


### PR DESCRIPTION
#### What does this PR do?
This PR will enable token and include it upon registration or login
#### Description of Task to be completed?
Users once registered via the registration endpoint, should receive a JWT to be required on all subsequent calls to all other endpoints that require authentication.
GIVEN user successfully signs up/registers or logs in
WHEN user passes appropriate JSON object to the register and or login endpoint
THEN user should receive a JWT as the response

NOTE
The app should no longer use sessions, but should use the newly implemented JWT strategy for authentication.

This feature will be of importance/ prerequisite for testing setup
<img width="1440" alt="screen shot 2018-10-24 at 09 25 30" src="https://user-images.githubusercontent.com/20015806/47412448-77bf3d00-d774-11e8-8409-5166c342dba1.png">
<img width="1440" alt="screen shot 2018-10-24 at 09 28 41" src="https://user-images.githubusercontent.com/20015806/47412504-9de4dd00-d774-11e8-9da0-64a0d69bbb81.png">
<img width="1440" alt="screen shot 2018-10-24 at 09 33 56" src="https://user-images.githubusercontent.com/20015806/47412517-a63d1800-d774-11e8-8a1d-a34876a01aa4.png">

#### How can this be tested manually?
On your local machine, clone the repository 

> https://github.com/andela/ah-sealteam

Navigate to the folder $ cd ah-sealteam
After running the server on 127.0.0.1:8000, run the test with postman
> POST 127.0.0.1:8000/api/users
`{
	"user":{
		"email":"dennisngeno@hotmail.com",
		"username":"was",
		"password":"testpassword"
	}
}`
>POST 127.0.0.1:8000/api/users/login
`
{
  "user":{
    "email": "dennisngeno@hotmail.com",
    "password": "testpassword"
  }
}
`
> GET 127.0.0.1:8000/api/user
#### What are the relevant pivotal tracker stories?
#161278906