### PR TITLE
[Bug #161492261] Implement password validation, only return token on

### DIFF
--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -21,7 +21,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
             token = token.split(" ")[1]
             payload = jwt.decode(token, settings.SECRET_KEY)
         except Exception as e:
-            raise exceptions.AuthenticationFailed("Invalid token what")
+            raise exceptions.AuthenticationFailed("Invalid token")
         try:
             user = User.objects.get(pk=payload['id'])
         except User.DoesNotExist:

--- a/authors/apps/authentication/tests/test_get_user.py
+++ b/authors/apps/authentication/tests/test_get_user.py
@@ -1,0 +1,33 @@
+"""This file will be used to test get user and also token"""
+from authors.apps.authentication.models import User
+from authors.base_test import BaseTestCase
+
+
+class TestRetrieveUser(BaseTestCase):
+    """This class will test user"""
+
+    def test_get_user(self):
+        """This will test get user"""
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get('/api/user', self.new_user, format='json')
+        assert response.status_code == 200
+        assert response.data["email"] == "testemail@gmail.com"
+        assert response.data["username"] == "mike"
+
+    def test_get_user_no_token(self):
+        response = self.client.get('/api/user', self.new_user, format='json')
+        assert response.status_code == 403
+        assert response.data["detail"] == "Authentication credentials were not provided."
+
+    def test_get_user_invalid_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + "jhdsbhjdsjdksjjdsjnk")
+        response = self.client.get('/api/user', self.new_user, format='json')
+        assert response.status_code == 403
+        assert response.data["detail"] == "Invalid token"
+
+    def test_get_doesnotexist_user(self):
+        User.objects.get(email=self.email).delete()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' +self.token)
+        response = self.client.get('/api/user', self.new_user, format='json')
+        assert response.status_code == 403
+        assert response.data["detail"] == "User does not exist"

--- a/authors/apps/authentication/tests/test_user_login.py
+++ b/authors/apps/authentication/tests/test_user_login.py
@@ -1,4 +1,5 @@
 "Test the login endpoint"
+from authors.apps.authentication.models import User
 from authors.base_test import BaseTestCase
 
 
@@ -19,8 +20,6 @@ class TestUserLogin(BaseTestCase):
             }
         response = self.client.post(self.login_url, data, format='json')
         self.assertEqual(response.status_code, 200)
-        assert response.data['email'] == self.email
-        assert response.data['username'] == self.username
         assert response.data.get("token")
 
     def test_user_login_with_invalid_password(self):
@@ -37,6 +36,7 @@ class TestUserLogin(BaseTestCase):
         assert response.data['errors']["error"][0] == "A user with this email " \
                                                       "and password was not found."
 
+    #
     def test_user_login_with_no_email(self):
         """
         Test with no email
@@ -50,6 +50,7 @@ class TestUserLogin(BaseTestCase):
         self.assertEqual(response.status_code, 400)
         assert response.data['errors']["email"][0] == "This field may not be blank."
 
+    #
     def test_user_login_with_no_password(self):
         """Test with no password"""
         data = {
@@ -60,6 +61,7 @@ class TestUserLogin(BaseTestCase):
         self.assertEqual(response.status_code, 400)
         assert response.data['errors']["password"][0] == "This field may not be blank."
 
+    #
     def test_user_login_without_an_account(self):
         """Login without account"""
         data = {
@@ -71,9 +73,13 @@ class TestUserLogin(BaseTestCase):
         assert response.data['errors']["error"][0] == "A user with this email " \
                                                       "and password was not found."
 
+    #
     def test_user_login_with_deactivated_account(self):
         """Login deactivated user"""
-        pass
-
-
-
+        user = User.objects.get(email=self.email)
+        user.is_active = False
+        user.save()
+        response = self.client.post(self.login_url, self.data_for_get_test, format='json')
+        self.assertEqual(response.status_code, 400)
+        assert response.data['errors']["error"][0] == "A user with this email " \
+                                                      "and password was not found."

--- a/authors/apps/authentication/tests/test_user_register.py
+++ b/authors/apps/authentication/tests/test_user_register.py
@@ -3,8 +3,6 @@ from rest_framework import status
 
 from authors.base_test import BaseTestCase
 
-from django.contrib.auth.tokens import default_token_generator
-
 
 class TestUserRegistration(BaseTestCase):
     """
@@ -18,8 +16,6 @@ class TestUserRegistration(BaseTestCase):
         """
         response = self.client.post(self.register_url, self.new_user, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        assert response.data['email'] == "asheuh@gmail.com"
-        assert response.data['username'] == "asheuh"
         assert response.data.get("token")
 
     def test_user_register_with_invalid_email(self):
@@ -28,19 +24,11 @@ class TestUserRegistration(BaseTestCase):
         :return:
         """
         data = {
-            "user": {
-                "email": self.wrongmail,
-                "username": self.username,
-                "password": "ajkjndsjns5d"
-            }
+            "email": self.wrongmail,
+            "username": self.username,
+            "password": "ajkjndsj4nsd"
         }
         response = self.client.post(self.register_url, data, format='json')
-        data={
-                "email":self.wrongmail,
-                "username":self.username,
-                "password": "ajkjndsjnsd"
-            }
-        response = self.client.post(self.register_url,data , format='json')
         self.assertEqual(response.status_code, 400)
         assert response.data['errors']["email"][0] == "Enter a valid email address."
 
@@ -50,13 +38,13 @@ class TestUserRegistration(BaseTestCase):
         :return:
         """
         data = {
-                "email": self.email,
-                "username": self.username,
-                "password": ""
-            }
+            "email": self.email,
+            "username": self.username,
+            "password": ""
+        }
         response = self.client.post(self.register_url, data, format='json')
         self.assertEqual(response.status_code, 400)
-        assert response.data['errors']["password"][0] == "This field may not be blank."
+        assert response.data['errors']["password"] == "Please provide a password"
 
     def test_user_register_with_no_email(self):
         """
@@ -64,32 +52,44 @@ class TestUserRegistration(BaseTestCase):
         :return:
         """
         data = {
-                "email": "",
-                "username": self.username,
-                "password": "sgds6sdhbd"
-            }
+            "email": "",
+            "username": self.username,
+            "password": "sgds6sdhbd"
+        }
         response = self.client.post(self.register_url, data, format='json')
         self.assertEqual(response.status_code, 400)
-        assert response.data['errors']["email"][0] == "This field may not be blank."
+        assert response.data['errors']["email"] == "Please provide an email"
+
+    def test_user_register_with_no_username(self):
+            """
+            Register with no email
+            :return:
+            """
+            data = {
+                "email": self.email,
+                "username": "",
+                "password": "sgds6sdhbd"
+            }
+            response = self.client.post(self.register_url, data, format='json')
+            self.assertEqual(response.status_code, 400)
+            assert response.data['errors']["username"] == "Please provide a an username"
 
     def test_password_no_digit(self):
         """Try to register with password with no digit"""
         my_user = {
-                "email": "newmail@gmail.com",
-                "username": "mineuser",
-                "password": "asghvdbjknfsadnkf"
-            }
+            "email": "newmail@gmail.com",
+            "username": "mineuser",
+            "password": "asghvdbjknfsadnkf"
+        }
         response = self.client.post(self.register_url, my_user, format='json')
         self.assertEqual(response.status_code, 400)
-        assert response.data['errors']["password"][0] == "Password should contain at least a digit"
+        assert response.data['errors']["password"] == "Password must be between 8 - 20 " \
+                                                      "characters and at least 1 digit"
 
     def test_register_if_user_already_exists(self):
         """Register with register user"""
         response = self.client.post(self.register_url, self.new_user, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        print(response)
-        assert response.data['email'] == "asheuh@gmail.com"
-        assert response.data['username'] == "asheuh"
         assert response.data.get("token")
         response = self.client.post(self.register_url, self.new_user, format='json')
         assert response.status_code == 400
@@ -100,34 +100,32 @@ class TestUserRegistration(BaseTestCase):
         response = self.client.post(self.register_url, self.new_user, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         data = {
-                "email": self.email
+            "email": self.email
         }
         response = self.client.post(self.forgot_password_url, data, format='json')
         self.assertEqual(response.status_code, 200)
         assert response.data['email'] == "Instructions sent to testemail@gmail.com. Kindly check your email"
 
-
     def test_forgot_password_request_with_invalid_email(self):
         response = self.client.post(self.register_url, self.new_user, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         data = {
-                "email": "wrongemail@gmail.com"
+            "email": "wrongemail@gmail.com"
         }
         response = self.client.post(self.forgot_password_url, data, format='json')
         self.assertEqual(response.status_code, 400)
-        assert response.data['errors']['error'][0] == "No records found with the email address. Create An Account To Continue."
-
+        assert response.data['errors']['error'][0] == "No records found with the email address." \
+                                                      " Create An Account To Continue."
 
     def test_reset_password(self):
         response = self.client.post(self.register_url, self.new_user, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         data = {
-                "email": self.email,
-                "password": self.password,
-                "token": "generated-token"
+            "email": self.email,
+            "password": self.password,
+            "token": "generated-token"
         }
         response = self.client.put(self.reset_password_url, data, format='json')
         self.assertEqual(response.status_code, 400)
-        print(response.data)
-        assert response.data["Message"] == "Invalid email address or token. Please check your email or generate another reset password email"
-        print(response)
+        assert response.data["Message"] == "Invalid email address or token. Please check " \
+                                           "your email or generate another reset password email"

--- a/authors/base_test.py
+++ b/authors/base_test.py
@@ -19,6 +19,7 @@ class BaseTestCase(TestCase):
         }
         self.register_url = reverse('authentication:register')
         self.user_url = reverse('authentication:update_user')
+
         self.username = "mike"
         self.wrongmail = "dennis mail.com"
         self.email = "testemail@gmail.com"
@@ -29,15 +30,13 @@ class BaseTestCase(TestCase):
         # this user will be used to test login
         User.objects.create_user(username=self.username,
                                  email=self.email, password=self.password)
-        data_for_get_test = {
+        self.data_for_get_test = {
                 "email": self.email,
                 "password": self.password
         }
-        response = self.client.post(self.login_url, data_for_get_test, format='json')
-        self.token = response.data["token"]
-        self.assertEqual(response.status_code, 200)
-        assert response.data['email'] == self.email
-        assert response.data['username'] == self.username
+        response = self.client.post(self.login_url, self.data_for_get_test, format='json')
         assert response.data.get("token")
+        self.token = response.data["token"]
+        assert response.status_code == 200
 
 


### PR DESCRIPTION
### What does this PR do
This PR will test the decoding token and signup and sign in payload and password validation.

### Description of Task to be completed?

1. This PR will test how decoding of Token by mocking get user and testing the different possible output. Check the test [here](https://github.com/andela/ah-sealteam/blob/bg-test-invalid-and-validation-161492261/authors/apps/authentication/tests/test_get_user.py)

2. It will also change the signup and login payload to only returning token. This was part of feed back by Our LFA that token can be decoded at front end.
<img width="913" alt="login_payload" src="https://user-images.githubusercontent.com/20015806/47838681-268cfa00-ddc1-11e8-9a3c-13d8224b45ef.png">
<img width="1280" alt="signup" src="https://user-images.githubusercontent.com/20015806/47838684-2a208100-ddc1-11e8-8d13-7104142042da.png">

3. The third fix will ensure that the password is first validated before raising DB validations 

> like Email already exists

 

### How should this be manually tested?*
On your git repo run
$ `git fetch origin pull/20/head:bg-test-invalid-and-validation-161492261`
checkout to 
$ `git checkout  bg-test-invalid-and-validation-161492261`
> register new user and login; at same time checking their payload
> Try to register you user again with invalid password and check payload 
### What are the relevant pivotal tracker stories?
[161492261](https://www.pivotaltracker.com/story/show/161492261)