### PR TITLE
[Feature #161278917] User should be able to like or dislike an article

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -14,8 +14,11 @@ from django.contrib.contenttypes.fields import GenericRelation, GenericForeignKe
 from cloudinary.models import CloudinaryField
 from django.utils import timezone
 from django.utils.text import slugify
-from ..authentication.models import User
+from django.db.models import Sum
+from django.utils.translation import ugettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
+from ..authentication.models import User
+
 
 
 class TaggedItem(models.Model):
@@ -43,6 +46,57 @@ def random_string_generator(size=4, chars=string.ascii_lowercase + string.digits
     return ''.join(random.choice(chars) for _ in range(size))
 
 
+class LikeDislikeManager(models.Manager):
+    """
+    Manager class for like and dislike
+    """
+    use_for_related_fields = True
+ 
+    def likes(self):
+        """
+        get all the likes for an object
+        """
+        return self.get_queryset().filter(vote__gt=0)
+ 
+    def dislikes(self):
+        """
+        get all the dislikes of an object
+        """
+        return self.get_queryset().filter(vote__lt=0)
+ 
+    def sum_rating(self):
+        """
+        obtain the aggregate likes/dislikes
+        """
+        return self.get_queryset().aggregate(Sum('vote')).get('vote__sum') or 0
+    
+    def articles(self):
+        """
+        obtain the votes of a particular user
+        """
+        return self.get_queryset().filter(content_type__model='article').order_by('-articles__published_at')
+
+class LikeDislike(models.Model):
+    """
+    Users should be able to like and/or dislike an article or comment.
+    This class creates the fields for like/dislike
+    """
+    LIKE = 1
+    DISLIKE = -1
+ 
+    VOTES = (
+        (DISLIKE, 'Dislike'),
+        (LIKE, 'Like')
+    )
+ 
+    vote = models.SmallIntegerField(verbose_name=_("vote"), choices=VOTES)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name=_("user"))
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    content_object = GenericForeignKey()
+    
+    objects = LikeDislikeManager()
+
 class Article(models.Model):
     """
     When a user registers in the application, this class create the models for
@@ -63,7 +117,7 @@ class Article(models.Model):
             null=True, max_length=20)
     favorited = models.BooleanField(default=False)
     content_html = models.TextField(editable=False)
-
+    votes = GenericRelation(LikeDislike, related_query_name='articles')
     objects = models.Manager()
 
     class Meta:

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -8,8 +8,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import PageNumberPagination
 
 from authors.apps.articles.utils import ChoicesField
-from .models import Article, TaggedItem, ArticleRating, Photo
-
+from .models import Article, TaggedItem, ArticleRating, Photo, LikeDislike
 
 class ArticlePagination(PageNumberPagination):
     """
@@ -100,6 +99,7 @@ class PhotoSerializer(serializers.Serializer):
     class Meta:
         model = Photo
         fields = ('article',)
+
 class RatingSerializer(serializers.ModelSerializer):
     article = serializers.ReadOnlyField(source='article.id')
     user = serializers.ReadOnlyField(source="user.username")
@@ -124,3 +124,12 @@ class RatingSerializer(serializers.ModelSerializer):
                                   "Consider updating your rating")
         instance = ArticleRating.objects.create(**validated_data)
         return instance
+
+class LikeDislikeSerializer(serializers.Serializer):
+    """
+    serializer class for the Like Dislike model
+    """
+    class Meta:
+        model = LikeDislike
+        pass
+    

--- a/authors/apps/articles/tests/test_like_dislike.py
+++ b/authors/apps/articles/tests/test_like_dislike.py
@@ -1,0 +1,66 @@
+"""
+This module tests like and dislike functionality
+"""
+from django.urls import reverse
+from authors.base_test import BaseTestCase
+from authors.apps.articles.models import LikeDislike
+
+class TestLikeDislikeArticle(BaseTestCase):
+    """
+    Testcase for user to like and/or dislike an article
+    """
+
+    def test_like_an_article(self):
+        """
+        Test than an authenticated user can like an article
+        """
+        # create a new article
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)
+        response = self.client.post(self.article_url, self.new_article, format='json')
+        self.assertEqual(response.status_code, 201)
+        slug = response.data.get("slug")
+        like_url = reverse("articles:article_like", kwargs={"slug":slug})
+        response2 = self.client.post(like_url)
+        self.assertEqual(response2.status_code, 201)
+        self.assertEqual(response2.data.get("like_count"), 1)
+        # when a user likes the same article twice, his like should be removed.
+        response3 = self.client.post(like_url)
+        self.assertEqual(response3.status_code, 201)
+        self.assertEqual(response3.data.get("like_count"), 0)
+
+    def test_dislike_an_article(self):
+        """
+        Test than an authenticated user can dislike an article
+        """
+        # create a new article
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)
+        response = self.client.post(self.article_url, self.new_article, format='json')
+        self.assertEqual(response.status_code, 201)
+        slug = response.data.get("slug")
+        dislike_url = reverse("articles:article_dislike", kwargs={"slug":slug})
+        response2 = self.client.post(dislike_url)
+        self.assertEqual(response2.status_code, 201)
+        self.assertEqual(response2.data.get("dislike_count"), 1)
+        # when a user dislikes the same article twice, his dislike should be removed.
+        response3 = self.client.post(dislike_url)
+        self.assertEqual(response3.status_code, 201)
+        self.assertEqual(response3.data.get("dislike_count"), 0)
+
+    def test_like_dislike_an_article(self):
+        """
+        Test than an authenticated user can only like or dislike an article
+        """
+        # create a new article
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)
+        response = self.client.post(self.article_url, self.new_article, format='json')
+        self.assertEqual(response.status_code, 201)
+        slug = response.data.get("slug")
+        dislike_url = reverse("articles:article_dislike", kwargs={"slug":slug})
+        response2 = self.client.post(dislike_url)
+        self.assertEqual(response2.status_code, 201)
+        self.assertEqual(response2.data.get("dislike_count"), 1)
+        # when a user likes an article that had disliked, his change should be reflected
+        response3 = self.client.post(reverse("articles:article_like", kwargs={"slug":slug}))
+        self.assertEqual(response3.status_code, 201)
+        self.assertEqual(response3.data.get("like_count"), 1)
+        self.assertEqual(response3.data.get("dislike_count"), 0)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -3,7 +3,8 @@
 """
 
 from django.urls import path
-from .views import ArticleAPIView, ArticleRetrieveAPIView, RateAPIView, RateRetrieveAPIView
+from .views import ArticleAPIView, ArticleRetrieveAPIView, LikeDislikeView, RateAPIView, RateRetrieveAPIView
+from .models import Article, LikeDislike
 
 app_name = 'articles'
 
@@ -11,5 +12,11 @@ urlpatterns = [
     path('', ArticleAPIView.as_view(), name='create_article'),
     path('<slug:slug>', ArticleRetrieveAPIView.as_view(), name="retrieve_article"),
     path('<slug:slug>/rate', RateAPIView.as_view(), name="create_get_rating"),
-    path('rate/detail/<int:rate_id>', RateRetrieveAPIView.as_view(), name="get_update_delete_rating")
+    path('rate/detail/<int:rate_id>', RateRetrieveAPIView.as_view(), name="get_update_delete_rating"),
+    path('<slug:slug>/like/',
+         LikeDislikeView.as_view(model=Article, vote_type=LikeDislike.LIKE),
+         name='article_like'),
+    path('<slug:slug>/dislike/',
+         LikeDislikeView.as_view(model=Article, vote_type=LikeDislike.DISLIKE),
+         name='article_dislike')
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -6,13 +6,14 @@ from rest_framework.generics import CreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
-
-from authors.apps.articles.permissions import IsAuthorOrReadOnly
-from authors.apps.articles.permissions import NotArticleOwner, IsRaterOrReadOnly
-from .models import Article
-from .models import ArticleRating
-from .serializers import ArticleSerializer
-from .serializers import RatingSerializer
+from authors.apps.articles.permissions import NotArticleOwner, IsRaterOrReadOnly, IsAuthorOrReadOnly
+from rest_framework import status
+from django.shortcuts import get_object_or_404
+from rest_framework.generics import CreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.response import Response
+from django.contrib.contenttypes.models import ContentType
+from .models import Article, LikeDislike, ArticleRating
+from .serializers import ArticleSerializer, LikeDislikeSerializer, RatingSerializer
 
 
 class ArticlePagination(PageNumberPagination):
@@ -187,3 +188,48 @@ class RateRetrieveAPIView(RetrieveUpdateDestroyAPIView):
         rate_delete = self.get_object()
         rate_delete.delete()
         return Response({"message": "Your rate was successfully deleted"}, status.HTTP_200_OK)
+
+class LikeDislikeView(CreateAPIView):
+    """
+    this class defines the endpoint for like and dislike
+    """
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+    serializer_class = LikeDislikeSerializer
+    model = None    # Data Model - Articles or Comments
+    vote_type = None # Vote type Like/Dislike
+ 
+    def post(self, request, slug):
+        """
+        This view enables a user to like or dislike an article
+        """
+        obj = self.model.objects.get(slug=slug)
+        # GenericForeignKey does not support get_or_create
+        # the code is therefore wrapped in a try.. except 
+        try:
+            like_dislike = LikeDislike.objects.get(
+                content_type=ContentType.objects.get_for_model(obj),
+                object_id=obj.id,
+                user=request.user )
+            # check if the user has liked or disliked the article or comment already
+            if like_dislike.vote is not self.vote_type:
+                like_dislike.vote = self.vote_type
+                like_dislike.save(update_fields=['vote'])
+                result = True
+            else:
+                # delete the existing record if the user is submitting a similar vote
+                like_dislike.delete()
+                result = False
+        except LikeDislike.DoesNotExist:
+            # user has never voted for the article, create new record.
+            obj.votes.create(user=request.user, vote=self.vote_type)
+            result = True
+ 
+        return Response({
+                    "result": result,
+                    "like_count": obj.votes.likes().count(),
+                    "dislike_count": obj.votes.dislikes().count(),
+                    "sum_rating": obj.votes.sum_rating()
+                },
+                content_type="application/json",
+                status=status.HTTP_201_CREATED
+            )

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,5 +1,6 @@
 python manage.py makemigrations authentication
 python manage.py makemigrations profiles
+psql $DATABASE_URL -c "DELETE FROM django_migrations WHERE app='articles';"
 python manage.py makemigrations articles
 python manage.py makemigrations
-python manage.py migrate
+python manage.py migrate --fake

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ cloudinary==1.14.0
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.1
-cssselect==1.0.3
 cryptography==2.3.1
+cssselect==1.0.3
 defusedxml==0.5.0
 dj-database-url==0.5.0
 Django==2.1.2
@@ -50,8 +50,8 @@ PyJWT==1.6.4
 pylint==2.1.1
 pylint-django==2.0.2
 pylint-plugin-utils==0.4
-pyquery==1.4.0
 pyOpenSSL==18.0.0
+pyquery==1.4.0
 pytest==3.9.2
 pytest-cov==2.6.0
 pytest-django==3.4.3


### PR DESCRIPTION
## What does this PR do?

Adds functionality to enable a user to like or dislike an article

## Description of Task to be completed?

When an authenticated user makes a request to the following endpoints:

Like: /api/articles/article-slug/like
Dislike: /api/articles/article-slug/dislike

They should be able to add their voice to the specified article

## How should this be manually tested?

```
$ git clone https://github.com/andela/ah-sealteam
$ cd ah-sealteam
$ python manage.py makemigrations articles
$ python manage.py migrate
$ python manage.py runserver
```
Post an article to the platform in order to obtain a slug. Alternatively, use an existing article slug. You should already be authenticated in order to access the endpoint.

## What are the relevant pivotal tracker stories?

[#161278917](https://www.pivotaltracker.com/n/projects/2205273/stories/1161278917)

## Screenshots (if appropriate) of the response you get

<img width="927" alt="screen shot 2018-11-06 at 17 04 42" src="https://user-images.githubusercontent.com/20772882/48069842-859aa680-e1e7-11e8-91ab-6fd03f77341e.png">

<img width="926" alt="screen shot 2018-11-06 at 17 05 16" src="https://user-images.githubusercontent.com/20772882/48069970-d6aa9a80-e1e7-11e8-83ad-552c9e504a20.png">

