### PR TITLE
#162409422 added missing serializer class for documentation page

### DIFF
--- a/authors/apps/usernotifications/views.py
+++ b/authors/apps/usernotifications/views.py
@@ -70,7 +70,7 @@ class ReadNotificationsAPIView(NotificationAPIView):
     """
     List all the Read  notifications for this user
     """
-
+    
     def notifications(self, request):
         return request.user.notifications.read()
 
@@ -78,7 +78,7 @@ class ReadNotificationView(UpdateAPIView):
     """
     Mark a notification as read for this user
     """
-
+    serializer_class = NotificationSerializer
     def update(self, request, *args, **kwargs):
         """
         handle put request to mark a notification as read


### PR DESCRIPTION
## what does this PR do

fixes a bug on the documentation page

## how should it be tested

- When you access the base url: http://127.0.0.1:8000, you should see the API documentation. 

## any background information 

-  a serializer class was missing in an API view that was causing an error on the documentation page. 

## PT story

[162409422](https://www.pivotaltracker.com/story/show/162409422)